### PR TITLE
Handle NilClass relation model builder the same way as `belongs_to` a…

### DIFF
--- a/lib/active_force/association/relation_model_builder.rb
+++ b/lib/active_force/association/relation_model_builder.rb
@@ -54,7 +54,7 @@ module ActiveForce
 
     class BuildFromNilClass < AbstractBuildFrom
       def call
-        association.is_a?(BelongsToAssociation) ? nil : []
+        association.is_a?(HasOneAssociation) || association.is_a?(BelongsToAssociation) ? nil : []
       end
     end
 

--- a/spec/active_force/association/relation_model_builder_spec.rb
+++ b/spec/active_force/association/relation_model_builder_spec.rb
@@ -56,6 +56,28 @@ module ActiveForce
             end
           end
         end
+
+        context 'has_one' do
+          let(:association){ HasOneAssociation.new(HasOneParent, :has_one_child) }
+
+          context 'with a value' do
+            let(:value) do
+              build_restforce_sobject 'Id' => '213'
+            end
+
+            it 'returns a child' do
+              expect(instance.build_relation_model).to be_a HasOneChild
+            end
+          end
+
+          context 'without a value' do
+            let(:value){ nil }
+
+            it 'returns nil' do
+              expect(instance.build_relation_model).to be_nil
+            end
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
…ssociation.