### PR TITLE
fix spec for find_by! method

### DIFF
--- a/spec/active_force/active_query_spec.rb
+++ b/spec/active_force/active_query_spec.rb
@@ -172,7 +172,7 @@ describe ActiveForce::ActiveQuery do
 
   describe "#find_by!" do
     it "raises if record not found" do
-      allow(client).to receive(:query).and_return(nil)
+      allow(client).to receive(:query).and_return(build_restforce_collection)
       expect { active_query.find_by!(field: 123) }.to raise_error(ActiveForce::RecordNotFound)
     end
   end

--- a/spec/support/restforce_factories.rb
+++ b/spec/support/restforce_factories.rb
@@ -1,5 +1,5 @@
 module RestforceFactories
-  def build_restforce_collection(array)
+  def build_restforce_collection(array=[])
     Restforce::Collection.new({ 'records' => array }, nil)
   end
 


### PR DESCRIPTION
when no results are found, the restforce client returns an empty Restforce::Collection, not nil