### PR TITLE
Enable optional aliasing of original Salesforce fields.

### DIFF
--- a/lib/active_force/sobject.rb
+++ b/lib/active_force/sobject.rb
@@ -22,6 +22,7 @@ module ActiveForce
     define_model_callbacks :build, :create, :update, :save, :destroy
 
     class_attribute :mappings, :table_name
+    class_attribute :alias_original_fields, default: false
 
     attr_accessor :id, :title
 
@@ -149,6 +150,7 @@ module ActiveForce
       cast_type = args.fetch(:as, :string)
       attribute field_name, cast_type
       define_attribute_methods field_name
+      alias_attribute(args[:from].downcase.to_sym, field_name) if alias_original_fields? && args[:from] && args[:from].downcase.to_sym != field_name
     end
 
     def modified_attributes

--- a/spec/active_force/sobject_spec.rb
+++ b/spec/active_force/sobject_spec.rb
@@ -14,6 +14,20 @@ describe ActiveForce::SObject do
     end
   end
 
+  describe ".alias_original_fields" do
+    let(:sobject){ Whizbang.build sobject_hash }
+
+    it 'aliases the original Salesforce fields' do
+      expect(sobject.checkbox).to eq sobject.checkbox_label
+      expect(sobject.text).to eq sobject.text_label
+      expect(sobject.date).to eq sobject.date_label
+      expect(sobject.datetime).to eq sobject.datetime_label
+      expect(sobject.picklist_multiselect).to eq sobject.picklist_multiselect_label
+      expect(sobject.boolean).to eq sobject.boolean_label
+      expect(sobject.percent).to eq sobject.percent_label
+    end
+  end
+
   describe ".build" do
     let(:sobject){ Whizbang.build sobject_hash }
 

--- a/spec/support/whizbang.rb
+++ b/spec/support/whizbang.rb
@@ -1,4 +1,5 @@
 class Whizbang < ActiveForce::SObject
+  self.alias_original_fields = true
 
   field :id,                   from: 'Id'
   field :checkbox,             from: 'Checkbox_Label', as: :boolean


### PR DESCRIPTION
By setting this class attribute before the fields in a class we can allow access to the original attribute names:
```
class MyClass < ActiveForce::SObject
  self.alias_original_fields = true

  # field definitions
  field :account_id,                                from: 'Account_Id__c'
end
```
So now both these work and return the same value:
```
myclass = MyClass.find(<some_id>)
myclass.account_id
myclass.account_id__c
```
