### PR TITLE
fix datetime to send using SF recognized format YYYY-MM-DDTHH:MM:SSZ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Not released
 
 ## 0.11.1
-* Fix `datetime` fields of SObjects to use iso(8601) format when sending to SF
+* Fix `datetime` fields of SObjects to use iso(8601) format when sending to SF (https://github.com/Beyond-Finance/active_force/pull/18)
 
 ## 0.11.0
 * Added support for 'or' and 'not' clauses (https://github.com/Beyond-Finance/active_force/pull/13)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Not released
 
+## 0.11.1
+* Fix `datetime` fields of SObjects to use iso(8601) format when sending to SF
 
 ## 0.11.0
 * Added support for 'or' and 'not' clauses (https://github.com/Beyond-Finance/active_force/pull/13)

--- a/lib/active_force/field.rb
+++ b/lib/active_force/field.rb
@@ -13,6 +13,8 @@ module ActiveForce
       case as
       when :multipicklist
         (value || Array.new).reject(&:empty?).join(';')
+      when :datetime
+        value.to_fs(:iso8601)
       else
         value
       end

--- a/lib/active_force/version.rb
+++ b/lib/active_force/version.rb
@@ -1,3 +1,3 @@
 module ActiveForce
-  VERSION = "0.10.0"
+  VERSION = "0.11.1"
 end

--- a/spec/active_force/field_spec.rb
+++ b/spec/active_force/field_spec.rb
@@ -23,5 +23,11 @@ describe ActiveForce::Field do
       names = field.new(:names, as: :multipicklist)
       expect(names.value_for_hash ['olvap', 'eloy']).to eq 'olvap;eloy'
     end
+
+    it 'a datetime should return a string like "YYYY-MM-DDTHH:MM:SSZ"' do
+      current_time = DateTime.now
+      names = field.new(:time, as: :datetime)
+      expect(names.value_for_hash current_time).to eq current_time.to_fs(:iso8601)
+    end
   end
 end


### PR DESCRIPTION
Repro steps:
Change a datetime field on an AF object using Time.zone.now, and update it in the database.

Before PR, this would error out. After PR, it will not error out.