### PR TITLE
Fix associations making API requests with missing keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Not released
 
-## 0.12.0
+## 0.11.2
 
 * Fix: prevent association methods from running queries when keys do not exist (https://github.com/Beyond-Finance/active_force/pull/20)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Not released
 
+## 0.12.0
+
+* Fix: prevent association methods from running queries when keys do not exist (https://github.com/Beyond-Finance/active_force/pull/20)
+
 ## 0.11.1
 * Fix `datetime` fields of SObjects to use iso(8601) format when sending to SF (https://github.com/Beyond-Finance/active_force/pull/18)
 

--- a/lib/active_force/association/association.rb
+++ b/lib/active_force/association/association.rb
@@ -39,11 +39,11 @@ module ActiveForce
         relationship_name.gsub /__c\z/, '__r'
       end
 
-      def find_target(owner)
-        if targetable?(owner)
+      def load_target(owner)
+        if loadable?(owner)
           target(owner)
         else
-          untargetable_value
+          target_when_unloadable
         end
       end
 
@@ -51,7 +51,7 @@ module ActiveForce
 
       attr_reader :parent
 
-      def targetable?(owner)
+      def loadable?(owner)
         owner&.persisted?
       end
 
@@ -59,7 +59,7 @@ module ActiveForce
         raise NoMethodError, 'target must be implemented'
       end
 
-      def untargetable_value
+      def target_when_unloadable
         nil
       end
 
@@ -67,8 +67,12 @@ module ActiveForce
         association = self
         method_name = relation_name
         parent.send(:define_method, method_name) do
-          association_cache.fetch(method_name) { association_cache[method_name] = association.find_target(self) }
+          association_cache.fetch(method_name) { association_cache[method_name] = association.load_target(self) }
         end
+      end
+
+      def define_assignment_method
+        raise NoMethodError, 'define_assignment_method must be implemented'
       end
 
       def infer_foreign_key_from_model(model)

--- a/lib/active_force/association/belongs_to_association.rb
+++ b/lib/active_force/association/belongs_to_association.rb
@@ -8,11 +8,11 @@ module ActiveForce
       private
 
       def loadable?(owner)
-        owner&.public_send(foreign_key).present?
+        foreign_key_value(owner).present?
       end
 
       def target(owner)
-        relation_model.find(owner.send(foreign_key))
+        relation_model.find(foreign_key_value(owner))
       end
 
       def default_relationship_name
@@ -21,6 +21,10 @@ module ActiveForce
 
       def default_foreign_key
         infer_foreign_key_from_model relation_model
+      end
+
+      def foreign_key_value(owner)
+        owner&.public_send(foreign_key)
       end
 
       def define_assignment_method

--- a/lib/active_force/association/belongs_to_association.rb
+++ b/lib/active_force/association/belongs_to_association.rb
@@ -7,7 +7,7 @@ module ActiveForce
 
       private
 
-      def targetable?(owner)
+      def loadable?(owner)
         owner&.public_send(foreign_key).present?
       end
 
@@ -16,7 +16,7 @@ module ActiveForce
       end
 
       def default_relationship_name
-        @parent.mappings[foreign_key].gsub /__c\z/, '__r'
+        parent.mappings[foreign_key].gsub(/__c\z/, '__r')
       end
 
       def default_foreign_key

--- a/lib/active_force/association/belongs_to_association.rb
+++ b/lib/active_force/association/belongs_to_association.rb
@@ -21,7 +21,8 @@ module ActiveForce
         _method = @relation_name
         @parent.send :define_method, _method do
           association_cache.fetch(_method) do
-            association_cache[_method] = association.relation_model.find(send association.foreign_key)
+            fk_value = send(association.foreign_key)
+            association_cache[_method] = fk_value.present? ? association.relation_model.find(fk_value) : nil
           end
         end
 

--- a/lib/active_force/association/has_many_association.rb
+++ b/lib/active_force/association/has_many_association.rb
@@ -2,8 +2,8 @@ module ActiveForce
   module Association
     class HasManyAssociation < Association
       def sfdc_association_field
-        name = relationship_name.gsub /__c\z/, '__r'
-        match = name.match /__r\z/
+        name = relationship_name.gsub(/__c\z/, '__r')
+        match = name.match(/__r\z/)
         # pluralize the table name, and append '__r' if it was there to begin with
         name.sub(match.to_s, '').pluralize + match.to_s
       end
@@ -20,14 +20,18 @@ module ActiveForce
         @parent.send :define_method, _method do
           association_cache.fetch _method do
             query = association.relation_model.query
-            if scope = association.options[:scoped_as]
-              if scope.arity > 0
-                query.instance_exec self, &scope
-              else
-                query.instance_exec &scope
-              end
-            end
-            association_cache[_method] = query.where association.foreign_key => self.id
+            association_cache[_method] = if id.present?
+                                           if (scope = association.options[:scoped_as])
+                                             if scope.arity.positive?
+                                               query.instance_exec self, &scope
+                                             else
+                                               query.instance_exec(&scope)
+                                             end
+                                           end
+                                           query.where association.foreign_key => id
+                                         else
+                                           query.none
+                                         end
           end
         end
 

--- a/lib/active_force/association/has_many_association.rb
+++ b/lib/active_force/association/has_many_association.rb
@@ -11,14 +11,14 @@ module ActiveForce
       private
 
       def default_foreign_key
-        infer_foreign_key_from_model @parent
+        infer_foreign_key_from_model parent
       end
 
       def target(owner)
         apply_scope(relation_model.query, owner).where(foreign_key => owner.id)
       end
 
-      def untargetable_value
+      def target_when_unloadable
         relation_model.none
       end
 

--- a/lib/active_force/association/has_one_association.rb
+++ b/lib/active_force/association/has_one_association.rb
@@ -12,7 +12,7 @@ module ActiveForce
         _method = @relation_name
         @parent.send :define_method, _method do
           association_cache.fetch(_method) do
-            association_cache[_method] = association.relation_model.find_by(association.foreign_key => self.id)
+            association_cache[_method] = id.present? ? association.relation_model.find_by(association.foreign_key => id) : nil
           end
         end
 

--- a/lib/active_force/association/has_one_association.rb
+++ b/lib/active_force/association/has_one_association.rb
@@ -8,7 +8,7 @@ module ActiveForce
       end
 
       def default_foreign_key
-        infer_foreign_key_from_model @parent
+        infer_foreign_key_from_model parent
       end
 
       def define_assignment_method

--- a/lib/active_force/association/has_one_association.rb
+++ b/lib/active_force/association/has_one_association.rb
@@ -3,26 +3,24 @@ module ActiveForce
     class HasOneAssociation < Association
       private
 
+      def target(owner)
+        relation_model.find_by(foreign_key => owner.id)
+      end
+
       def default_foreign_key
         infer_foreign_key_from_model @parent
       end
 
-      def define_relation_method
+      def define_assignment_method
         association = self
-        _method = @relation_name
-        @parent.send :define_method, _method do
-          association_cache.fetch(_method) do
-            association_cache[_method] = id.present? ? association.relation_model.find_by(association.foreign_key => id) : nil
-          end
-        end
-
-        @parent.send :define_method, "#{_method}=" do |other|
+        method_name = relation_name
+        parent.send :define_method, "#{method_name}=" do |other|
           value_to_set = other.nil? ? nil : self.id
           other = other.first if other.is_a?(Array)
           # Do we change the object that was passed in or do we modify the already associated object?
-          obj_to_change = value_to_set ? other : self.send(association.relation_name)
-          obj_to_change.send "#{ association.foreign_key }=", value_to_set
-          association_cache[_method] = other
+          obj_to_change = value_to_set ? other : send(method_name)
+          obj_to_change.send "#{association.foreign_key}=", value_to_set
+          association_cache[method_name] = other
         end
       end
     end

--- a/lib/active_force/version.rb
+++ b/lib/active_force/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActiveForce
-  VERSION = "0.11.1"
+  VERSION = '0.12.0'
 end

--- a/lib/active_force/version.rb
+++ b/lib/active_force/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActiveForce
-  VERSION = '0.12.0'
+  VERSION = '0.11.2'
 end

--- a/spec/active_force/association_spec.rb
+++ b/spec/active_force/association_spec.rb
@@ -47,6 +47,19 @@ describe ActiveForce::SObject do
       end
     end
 
+    context 'when primary key is blank' do
+      let(:post) { Post.new }
+
+      it 'does not make any queries' do
+        post.comments.to_a
+        expect(client).not_to have_received :query
+      end
+
+      it 'returns empty' do
+        expect(post.comments.to_a).to be_empty
+      end
+    end
+
     context 'when the SObject is namespaced' do
       let(:account){ Foo::Account.new(id: '1') }
 
@@ -124,6 +137,19 @@ describe ActiveForce::SObject do
       expect(HasOneChild).to receive(:find_by).once.and_return(has_one_child)
       has_one_parent.has_one_child.id
       has_one_parent.has_one_child.id
+    end
+
+    context 'when primary key is blank' do
+      let(:parent) { HasOneParent.new }
+
+      it 'does not make any queries' do
+        parent.has_one_child
+        expect(client).not_to have_received :query
+      end
+
+      it 'returns nil' do
+        expect(parent.has_one_child).to be_nil
+      end
     end
 
     describe "assignments" do
@@ -213,6 +239,19 @@ describe ActiveForce::SObject do
       expect(client).to receive(:query).once
       comment.post
       comment.post
+    end
+
+    context 'when foreign key is blank' do
+      let(:comment) { Comment.new(id: '1') }
+
+      it 'does not make any queries' do
+        comment.post
+        expect(client).not_to have_received :query
+      end
+
+      it 'returns nil' do
+        expect(comment.post).to be_nil
+      end
     end
 
     describe "assignments" do

--- a/spec/active_force/sobject_spec.rb
+++ b/spec/active_force/sobject_spec.rb
@@ -226,7 +226,9 @@ describe ActiveForce::SObject do
 
     describe 'self.create' do
       before do
-        expect(client).to receive(:create!).with(Whizbang.table_name, 'Text_Label' => 'some text', 'Updated_From__c'=>'Rails').and_return('id')
+        expect(client).to receive(:create!)
+          .with(Whizbang.table_name, { 'Text_Label' => 'some text', 'Updated_From__c' => 'Rails' })
+          .and_return('id')
       end
 
       it 'should create a new instance' do


### PR DESCRIPTION
Fixes #19 

Association methods were always running queries, even if the SObject instances did not have the requisite foreign or primary keys.  This PR fixes that.

The PR also refactors `Association` and its subclasses a bit.  This includes raising `define_relation_method` to the base class to reduce repetition and make the requirements for inheritors of `Association` clearer and less burdensome.  Also, it splits `define_assignment_method` out into its own method for inheritors to implement (abstracting this more seemed out of scope for this PR).  I'd be happy to revise this refactoring or move these changes to a different PR if desired, since they're not essential to fixing the bug.