### PR TITLE
Fix has_one assignment when receiver does not have id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Not released
 
+## 0.11.3
+
+* Fix has_one assignment when receiver does not have id (https://github.com/Beyond-Finance/active_force/pull/23)
+
 ## 0.11.2
 
 * Fix: prevent association methods from running queries when keys do not exist (https://github.com/Beyond-Finance/active_force/pull/20)

--- a/lib/active_force/association/has_one_association.rb
+++ b/lib/active_force/association/has_one_association.rb
@@ -15,11 +15,13 @@ module ActiveForce
         association = self
         method_name = relation_name
         parent.send :define_method, "#{method_name}=" do |other|
-          value_to_set = other.nil? ? nil : self.id
           other = other.first if other.is_a?(Array)
-          # Do we change the object that was passed in or do we modify the already associated object?
-          obj_to_change = value_to_set ? other : send(method_name)
-          obj_to_change.send "#{association.foreign_key}=", value_to_set
+          if persisted?
+            value_to_set = other.nil? ? nil : id
+            # Do we change the object that was passed in or do we modify the already associated object?
+            obj_to_change = value_to_set ? other : send(method_name)
+            obj_to_change.send "#{association.foreign_key}=", value_to_set
+          end
           association_cache[method_name] = other
         end
       end

--- a/lib/active_force/association/has_one_association.rb
+++ b/lib/active_force/association/has_one_association.rb
@@ -12,17 +12,17 @@ module ActiveForce
       end
 
       def define_assignment_method
-        association = self
+        foreign_key = self.foreign_key
         method_name = relation_name
-        parent.send :define_method, "#{method_name}=" do |other|
-          other = other.first if other.is_a?(Array)
-          if persisted?
-            value_to_set = other.nil? ? nil : id
-            # Do we change the object that was passed in or do we modify the already associated object?
-            obj_to_change = value_to_set ? other : send(method_name)
-            obj_to_change.send "#{association.foreign_key}=", value_to_set
+        parent.send :define_method, "#{method_name}=" do |new_target|
+          new_target = new_target.first if new_target.is_a?(Array)
+          if new_target.present?
+            new_target.public_send("#{foreign_key}=", id)
+          else
+            current_target = public_send(method_name)
+            current_target&.public_send("#{foreign_key}=", nil)
           end
-          association_cache[method_name] = other
+          association_cache[method_name] = new_target
         end
       end
     end

--- a/lib/active_force/version.rb
+++ b/lib/active_force/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActiveForce
-  VERSION = '0.11.2'
+  VERSION = '0.11.3'
 end

--- a/spec/active_force/association_spec.rb
+++ b/spec/active_force/association_spec.rb
@@ -165,10 +165,17 @@ describe ActiveForce::SObject do
 
       it 'accepts assignment of an existing object as an association' do
         expect(client).to_not receive(:query)
-        other_child = HasOneChild.new(id: "2")
+        other_child = HasOneChild.new(id: '2')
         has_one.has_one_child = other_child
         expect(has_one.has_one_child.has_one_parent_id).to eq has_one.id
         expect(has_one.has_one_child).to eq other_child
+      end
+
+      it 'uses first element if given Array' do
+        first_child = HasOneChild.new(id: '2')
+        has_one.has_one_child = [first_child, HasOneChild.new(id: '3')]
+        expect(has_one.has_one_child.has_one_parent_id).to eq has_one.id
+        expect(has_one.has_one_child).to eq first_child
       end
 
       it 'can desassociate an object by setting it as nil' do
@@ -177,8 +184,35 @@ describe ActiveForce::SObject do
         expect(old_child.has_one_parent_id).to eq nil
         expect(has_one.has_one_child).to eq nil
       end
-    end
 
+      context 'when primary key is blank' do
+        let(:child) { HasOneChild.new }
+        let(:parent) { HasOneParent.new }
+
+        it 'accepts assignment' do
+          parent.has_one_child = child
+          expect(parent.has_one_child).to eq(child)
+        end
+
+        it 'accepts reassignment' do
+          parent.has_one_child = child
+          other_child = HasOneChild.new(id: 'x')
+          parent.has_one_child = other_child
+          expect(parent.has_one_child).to eq(other_child)
+        end
+
+        it 'accepts nil assignment' do
+          parent.has_one_child = child
+          parent.has_one_child = nil
+          expect(parent.has_one_child).to be_nil
+        end
+
+        it 'assigns the first element if given an array' do
+          parent.has_one_child = [child, 'something else']
+          expect(parent.has_one_child).to eq(child)
+        end
+      end
+    end
 
     context 'when the SObject is namespaced' do
       let(:attachment){ Foo::Attachment.new(id: '1', lead_id: '2') }


### PR DESCRIPTION
Fixes #22

Assigning to a `has_one` "attribute" was throwing `NoMethodError` when the object did not have an id.

Rearranged the assignment method a bit to make the logic clearer.  Although, see [comment](https://github.com/Beyond-Finance/active_force/pull/23/files#r1154605247) on whether this is the desired behavior.