### PR TITLE
Format Time values correctly in where conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Not released
 
+## 0.11.4
+
+* Fix `Time` value formatting in `.where` (https://github.com/Beyond-Finance/active_force/pull/28)
+
 ## 0.11.3
 
 * Fix has_one assignment when receiver does not have id (https://github.com/Beyond-Finance/active_force/pull/23)

--- a/lib/active_force/active_query.rb
+++ b/lib/active_force/active_query.rb
@@ -165,6 +165,8 @@ module ActiveForce
         "'#{quote_string(value)}'"
       when NilClass
         'NULL'
+      when Time
+        value.iso8601
       else
         value.to_s
       end

--- a/lib/active_force/version.rb
+++ b/lib/active_force/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActiveForce
-  VERSION = '0.11.3'
+  VERSION = '0.11.4'
 end

--- a/spec/active_force/active_query_spec.rb
+++ b/spec/active_force/active_query_spec.rb
@@ -63,6 +63,24 @@ describe ActiveForce::ActiveQuery do
       expect(active_query.to_s).to end_with("(Field__c = 'hello')")
     end
 
+    it "formats as YYYY-MM-DDThh:mm:ss-hh:mm and does not enclose in quotes if it's a DateTime" do
+      value = DateTime.now
+      active_query.where(field: value)
+      expect(active_query.to_s).to end_with("(Field__c = #{value.iso8601})")
+    end
+
+    it "formats as YYYY-MM-DDThh:mm:ss-hh:mm and does not enclose in quotes if it's a Time" do
+      value = Time.now
+      active_query.where(field: value)
+      expect(active_query.to_s).to end_with("(Field__c = #{value.iso8601})")
+    end
+
+    it "formats as YYYY-MM-DD and does not enclose in quotes if it's a Date" do
+      value = Date.today
+      active_query.where(field: value)
+      expect(active_query.to_s).to end_with("(Field__c = #{value.iso8601})")
+    end
+
     it "puts NULL when a field is set as nil" do
       active_query.where field: nil
       expect(active_query.to_s).to end_with("(Field__c = NULL)")
@@ -91,6 +109,24 @@ describe ActiveForce::ActiveQuery do
         expect(active_query.to_s).to eq("SELECT Id FROM table_name WHERE (Field__c = 123 AND Other_Field__c = 321 AND Name = 'Bob')")
       end
 
+      it 'formats as YYYY-MM-DDThh:mm:ss-hh:mm and does not enclose in quotes if value is a DateTime' do
+        value = DateTime.now
+        active_query.where('Field__c > ?', value)
+        expect(active_query.to_s).to end_with("(Field__c > #{value.iso8601})")
+      end
+
+      it 'formats as YYYY-MM-DDThh:mm:ss-hh:mm and does not enclose in quotes if value is a Time' do
+        value = Time.now
+        active_query.where('Field__c > ?', value)
+        expect(active_query.to_s).to end_with("(Field__c > #{value.iso8601})")
+      end
+
+      it 'formats as YYYY-MM-DD and does not enclose in quotes if value is a Date' do
+        value = Date.today
+        active_query.where('Field__c > ?', value)
+        expect(active_query.to_s).to end_with("(Field__c > #{value.iso8601})")
+      end
+
       it 'complains when there given an incorrect number of bind parameters' do
         expect{
           active_query.where('Field__c = ? AND Other_Field__c = ? AND Name = ?', 123, 321)
@@ -106,6 +142,24 @@ describe ActiveForce::ActiveQuery do
         it 'accepts nil bind parameters' do
           active_query.where('Field__c = :field', field: nil)
           expect(active_query.to_s).to eq("SELECT Id FROM table_name WHERE (Field__c = NULL)")
+        end
+
+        it 'formats as YYYY-MM-DDThh:mm:ss-hh:mm and does not enclose in quotes if value is a DateTime' do
+          value = DateTime.now
+          active_query.where('Field__c < :field', field: value)
+          expect(active_query.to_s).to end_with("(Field__c < #{value.iso8601})")
+        end
+
+        it 'formats as YYYY-MM-DDThh:mm:ss-hh:mm and does not enclose in quotes if value is a Time' do
+          value = Time.now
+          active_query.where('Field__c < :field', field: value)
+          expect(active_query.to_s).to end_with("(Field__c < #{value.iso8601})")
+        end
+
+        it 'formats as YYYY-MM-DD and does not enclose in quotes if value is a Date' do
+          value = Date.today
+          active_query.where('Field__c < :field', field: value)
+          expect(active_query.to_s).to end_with("(Field__c < #{value.iso8601})")
         end
 
         it 'accepts multiple bind parameters' do


### PR DESCRIPTION
Fixes #25

Also added tests for other date types.  `Date` and `DateTime` already worked because `#to_s` [returns the ISO 8601 format](https://ruby-doc.org/stdlib-2.5.1/libdoc/date/rdoc/Date.html#method-i-to_s) for those.  `Time#to_s`, however, adds incorrect spaces and time zone indicators that creates malformed SOQL queries.