### PR TITLE
Escape single quotation mark and backslash when quoting string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Not released
 
+## 0.11.4
+* Properly escape single quote (https://github.com/Beyond-Finance/active_force/pull/29)
+
 ## 0.11.3
 
 * Fix has_one assignment when receiver does not have id (https://github.com/Beyond-Finance/active_force/pull/23)

--- a/lib/active_force/active_query.rb
+++ b/lib/active_force/active_query.rb
@@ -162,7 +162,7 @@ module ActiveForce
     def enclose_value value
       case value
       when String
-        "'#{quote_string(value)}'"
+        quote_string(value)
       when NilClass
         'NULL'
       else
@@ -171,8 +171,7 @@ module ActiveForce
     end
 
     def quote_string(s)
-      # From activerecord/lib/active_record/connection_adapters/abstract/quoting.rb, version 4.1.5, line 82
-      s.gsub(/\\/, '\&\&').gsub(/'/, "''")
+      "'#{s.gsub(/(['\\])/, '\\\\\\1')}'"
     end
 
     def result

--- a/lib/active_force/version.rb
+++ b/lib/active_force/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActiveForce
-  VERSION = '0.11.3'
+  VERSION = '0.11.4'
 end

--- a/spec/active_force/active_query_spec.rb
+++ b/spec/active_force/active_query_spec.rb
@@ -196,7 +196,7 @@ describe ActiveForce::ActiveQuery do
     let(:quote_input){ "' OR Id!=NULL OR Id='" }
     let(:backslash_input){ "\\" }
     let(:number_input){ 123 }
-    let(:expected_query){ "SELECT Id FROM table_name WHERE (Backslash_Field__c = '\\\\' AND NumberField = 123 AND QuoteField = ''' OR Id!=NULL OR Id=''')" }
+    let(:expected_query){ "SELECT Id FROM table_name WHERE (Backslash_Field__c = '\\\\' AND NumberField = 123 AND QuoteField = '\\' OR Id!=NULL OR Id=\\'')" }
 
     it 'escapes quotes and backslashes in bind parameters' do
       active_query.where('Backslash_Field__c = :backslash_field AND NumberField = :number_field AND QuoteField = :quote_field', number_field: number_input, backslash_field: backslash_input, quote_field: quote_input)
@@ -210,7 +210,7 @@ describe ActiveForce::ActiveQuery do
 
     it 'escapes quotes and backslashes in hash conditions' do
       active_query.where(backslash_field: backslash_input, number_field: number_input, quote_field: quote_input)
-      expect(active_query.to_s).to eq("SELECT Id FROM table_name WHERE (Backslash_Field__c = '\\\\') AND (NumberField = 123) AND (QuoteField = ''' OR Id!=NULL OR Id=''')")
+      expect(active_query.to_s).to eq("SELECT Id FROM table_name WHERE (Backslash_Field__c = '\\\\') AND (NumberField = 123) AND (QuoteField = '\\' OR Id!=NULL OR Id=\\'')")
     end
   end
 


### PR DESCRIPTION
Fixes: https://github.com/Beyond-Finance/active_force/issues/24

Currently implementation improperly escapes the Quotation.  It prevents SOQL injection by forcing it into invalid SOQL statement.  However, we have use cases where first name of Lead may contain `'`. Example: `O'Dell`

Note:  This does not handle escaping LIKE expression wildcards such as `%` and `_`.  This is a cause for concern if there are any user provided fields that does a LIKE type of search.  It's possible to add it to gsub to escape those characters to be on the safe side, but it has potential to break existing functionality.