### PR TITLE
add .describe to SObject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Not released
 
+## 0.12.0
+
+* Add `.describe` to `SObject` to allow convenient metadata fetching (https://github.com/Beyond-Finance/active_force/pull/36)
+
 ## 0.11.4
 * Properly escape single quote (https://github.com/Beyond-Finance/active_force/pull/29)
 * Fix `Time` value formatting in `.where` (https://github.com/Beyond-Finance/active_force/pull/28)

--- a/lib/active_force/sobject.rb
+++ b/lib/active_force/sobject.rb
@@ -52,6 +52,10 @@ module ActiveForce
       ActiveForce::ActiveQuery.new self
     end
 
+    def self.describe
+      sfdc_client.describe(table_name)
+    end
+
     attr_accessor :build_attributes
     def self.build mash, association_mapping={}
       return unless mash

--- a/lib/active_force/version.rb
+++ b/lib/active_force/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActiveForce
-  VERSION = '0.11.4'
+  VERSION = '0.12.0'
 end

--- a/spec/active_force/sobject_spec.rb
+++ b/spec/active_force/sobject_spec.rb
@@ -93,6 +93,25 @@ describe ActiveForce::SObject do
     end
   end
 
+  describe '.describe' do
+    subject { Whizbang.describe }
+
+    let(:describe_response) { { 'fields' => [] } }
+
+    before do
+      allow(client).to receive(:describe).and_return(describe_response)
+    end
+
+    it 'passes table_name to sfdc_client.describe' do
+      subject
+      expect(client).to have_received(:describe).with(Whizbang.table_name)
+    end
+
+    it 'returns response from describe' do
+      expect(subject).to eq(describe_response)
+    end
+  end
+
   describe "CRUD" do
     let(:instance){ Whizbang.new(id: '1') }
 


### PR DESCRIPTION
Closes #31 

Adds a `.describe` class method to `SObject` to make it more convenient to get the metadata for an object.

Bumped a minor version, since this adds functionality.