### PR TITLE
Memoize the `ActiveForce::Mapping#mappings` Hash since it is based on…

### DIFF
--- a/lib/active_force/mapping.rb
+++ b/lib/active_force/mapping.rb
@@ -13,7 +13,7 @@ module ActiveForce
     end
 
     def mappings
-      Hash[fields.map { |field, attr| [field, attr.sfdc_name] }]
+      @mappings ||= Hash[fields.map { |field, attr| [field, attr.sfdc_name] }]
     end
 
     def sfdc_names

--- a/lib/active_force/sobject.rb
+++ b/lib/active_force/sobject.rb
@@ -179,7 +179,7 @@ module ActiveForce
         field = key
       else
         # Assume key is an SFDC column
-        field = mappings.invert[key]
+        field = mappings.key(key)
       end
       send "#{field}=", value if field && respond_to?(field)
     end


### PR DESCRIPTION
… the fields and those are generally only set when the class is loaded.  Also use `Hash#key` which returns the key for a value rather than `Hash#invert` which creates a new Hash with key/value inverted.