### PR TITLE
Make all parameters in RecordNotFound.new optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Not released
 
+## 0.13.1
+
+- Fix constructor of `ActiveForce::RecordNotFound` (https://github.com/Beyond-Finance/active_force/pull/44)
 - Add `.to_json` and `.as_json` to `SObject` to allow JSON serialization (https://github.com/Beyond-Finance/active_force/pull/37)
 - Memoize the `ActiveForce::Mapping#mappings` Hash since it is based on the fields and those are generally only set when the class is loaded. Also use `Hash#key` which returns the key for a value rather than `Hash#invert` which creates a new Hash with key/value inverted. (https://github.com/Beyond-Finance/active_force/pull/41)
 

--- a/lib/active_force/active_query.rb
+++ b/lib/active_force/active_query.rb
@@ -6,8 +6,13 @@ module ActiveForce
   class PreparedStatementInvalid < ArgumentError; end
 
   class RecordNotFound < StandardError
-    def initialize(table_name, conditions)
-      super("Couldn't find #{table_name} with #{conditions}")
+    attr_reader :table_name, :conditions
+
+    def initialize(message = nil, table_name = nil, conditions = nil)
+      @table_name = table_name
+      @conditions = conditions
+
+      super(message)
     end
   end
 
@@ -71,7 +76,7 @@ module ActiveForce
 
     def find!(id)
       result = find(id)
-      raise RecordNotFound.new(table_name, id: id) if result.nil?
+      raise RecordNotFound.new("Couldn't find #{table_name} with id #{id}", table_name, id: id) if result.nil?
 
       result
     end
@@ -82,7 +87,7 @@ module ActiveForce
 
     def find_by!(conditions)
       result = find_by(conditions)
-      raise RecordNotFound.new(table_name, conditions) if result.nil?
+      raise RecordNotFound.new("Couldn't find #{table_name} with #{conditions}", table_name, conditions) if result.nil?
 
       result
     end

--- a/lib/active_force/version.rb
+++ b/lib/active_force/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActiveForce
-  VERSION = '0.13.0'
+  VERSION = '0.13.1'
 end

--- a/spec/active_force/active_query_spec.rb
+++ b/spec/active_force/active_query_spec.rb
@@ -263,7 +263,7 @@ describe ActiveForce::ActiveQuery do
 
       it 'raises RecordNotFound' do
         expect { active_query.find!(id) }
-          .to raise_error(ActiveForce::RecordNotFound, "Couldn't find #{sobject.table_name} with #{{ id: id }}")
+          .to raise_error(ActiveForce::RecordNotFound, "Couldn't find #{sobject.table_name} with id #{id}")
       end
     end
   end

--- a/spec/active_force/sobject_spec.rb
+++ b/spec/active_force/sobject_spec.rb
@@ -305,7 +305,7 @@ describe ActiveForce::SObject do
 
     it 'raises RecordNotFound if nothing found' do
       expect { Whizbang.find!(id) }
-        .to raise_error(ActiveForce::RecordNotFound, "Couldn't find #{Whizbang.table_name} with #{{ id: id }}")
+        .to raise_error(ActiveForce::RecordNotFound, "Couldn't find #{Whizbang.table_name} with id #{id}")
     end
   end
 


### PR DESCRIPTION
Parameterless constructor calls were being made in Glue tests, so we need these to be optional.