### PR TITLE
SAL-1478: Implement the loaded? functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Not released
 
+## 0.13.2
+- Add `#loaded?` method for ActiveQueries to allow the detection of records loaded in memory or pending to be loaded. (https://github.com/Beyond-Finance/active_force/pull/45)
+
 ## 0.13.1
 
 - Fix constructor of `ActiveForce::RecordNotFound` (https://github.com/Beyond-Finance/active_force/pull/44)

--- a/lib/active_force/active_query.rb
+++ b/lib/active_force/active_query.rb
@@ -107,6 +107,10 @@ module ActiveForce
       where(id: '1'*18).where(id: '0'*18)
     end
 
+    def loaded?
+      @records.present?
+    end
+
     private
 
     def build_condition(args, other=[])

--- a/lib/active_force/active_query.rb
+++ b/lib/active_force/active_query.rb
@@ -108,7 +108,7 @@ module ActiveForce
     end
 
     def loaded?
-      @records.present?
+      !@records.nil?
     end
 
     private

--- a/lib/active_force/version.rb
+++ b/lib/active_force/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActiveForce
-  VERSION = '0.13.1'
+  VERSION = '0.13.2'
 end

--- a/spec/active_force/active_query_spec.rb
+++ b/spec/active_force/active_query_spec.rb
@@ -315,4 +315,24 @@ describe ActiveForce::ActiveQuery do
       active_query.none.to_a
     end
   end
+
+  describe '#loaded?' do
+    subject { active_query.loaded? }
+
+    before do
+      active_query.instance_variable_set(:@records, records)
+    end
+
+    context 'when there are records loaded in memory' do
+      let(:records) { nil }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context 'when there are records loaded in memory' do
+      let(:records) { [build_restforce_sobject(id: 1)] }
+
+      it { is_expected.to be_truthy }
+    end
+  end
 end


### PR DESCRIPTION
# 🤔 What issue does this fix?

### Context

In order to optimise the performance of the services at Glue that are manipulating information at Salesforce through the ActiveForce gem, we would require an equivalent version to the loaded? method available for ActiveRecord associations. The objective of this card is to create that method.

### Acceptance criteria

* A loaded? method has been created for ActiveForce::ActiveQuery instances so we can determine if an association has already bee loaded on memory or not.

# 🍂 Before You Submit:

<!-- Check steps as necessary - this list is a reminder -->

- [x] Did you write tests?
- [ ] Did you write [documentation on Notion](https://www.notion.so/30da1978bf5e4370960ea2e7dd4c6940?v=d86eb275909341bc9deeb704e6cd876a)? (N/A)
- [x] Did you lint?
- [x] Did you run tests?
- [x] Did you link this PR in Trello?
- [ ] Did you update any env changes in the `.env.example` and on [Notion](https://www.notion.so/1e85593da10744e09affb7642540c83f?v=88550674a18b43789f9acdb7bf518676)? (N/A)

# 🛷 Deployment Considerations

<!-- What do we need to know to deploy this code out? -->

- [ ] Data Migrations (N/A)
- [ ] Schema Migrations (N/A)
- [ ] Dependencies (N/A)

# 🧪 How to Test

* We have implemented some tests for this new logic. We can rely on them
* It's possible to test it from the flue repository pointing to the local version of the active force gem and taking any `ActiveForce::ActiveQuery` and checking if `loaded?` is working as expected. 
