### PR TITLE
Add pluck method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Not released
 
+- Add `pluck` query method (https://github.com/Beyond-Finance/active_force/pull/51)
 - Add `scoped_as` option to `has_one` association (https://github.com/Beyond-Finance/active_force/pull/50)
 - Add `default` to model fields (https://github.com/Beyond-Finance/active_force/pull/49)
 

--- a/lib/active_force/sobject.rb
+++ b/lib/active_force/sobject.rb
@@ -29,7 +29,8 @@ module ActiveForce
 
     class << self
       extend Forwardable
-      def_delegators :query, :not, :or, :where, :first, :last, :all, :find, :find!, :find_by, :find_by!, :sum, :count, :includes, :limit, :order, :select, :none
+      def_delegators :query, :not, :or, :where, :first, :last, :all, :find, :find!, :find_by, :find_by!, :sum, :count,
+                     :includes, :limit, :order, :select, :none, :pluck
       def_delegators :mapping, :table, :table_name, :custom_table?, :mappings
 
       private

--- a/spec/active_force/sobject_spec.rb
+++ b/spec/active_force/sobject_spec.rb
@@ -342,6 +342,12 @@ describe ActiveForce::SObject do
       expect(Whizbang.pluck).to eq([])
     end
 
+    it 'works with another query' do
+      expected = 'SELECT Id, Text_Label FROM Whizbang__c WHERE (Checkbox_Label = true)'
+      Whizbang.where(checkbox: true).pluck(:id, :text)
+      expect(client).to have_received(:query).with(expected)
+    end
+
     context 'when given no fields' do
       it 'queries for all fields' do
         expected = "SELECT #{Whizbang.fields.join ', '} FROM Whizbang__c"

--- a/spec/active_force/sobject_spec.rb
+++ b/spec/active_force/sobject_spec.rb
@@ -330,6 +330,65 @@ describe ActiveForce::SObject do
     end
   end
 
+  describe '#pluck' do
+    let(:record_attributes) { [] }
+
+    before do
+      collection = build_restforce_collection(record_attributes.map { |a| build_restforce_sobject(a) })
+      allow(client).to receive(:query).and_return(collection)
+    end
+
+    it 'returns empty array if no records returned from query' do
+      expect(Whizbang.pluck).to eq([])
+    end
+
+    context 'when given no fields' do
+      it 'queries for all fields' do
+        expected = "SELECT #{Whizbang.fields.join ', '} FROM Whizbang__c"
+        Whizbang.pluck
+        expect(client).to have_received(:query).with(expected)
+      end
+    end
+
+    context 'when given one field' do
+      let(:ids) { ['a', 'b', 1] }
+      let(:record_attributes) { ids.map { |v| { 'Id' => v } } }
+
+      it 'queries for only that field' do
+        expected = 'SELECT Id FROM Whizbang__c'
+        Whizbang.pluck(:id)
+        expect(client).to have_received(:query).with(expected)
+      end
+
+      it 'returns an array of casted values for that field' do
+        expect(Whizbang.pluck(:id)).to match_array(ids.map(&:to_s))
+      end
+    end
+
+    context 'when given more than one field' do
+      let(:record_attributes) do
+        [
+          { 'Text_Label' => 'test1', 'Date_Label' => '2023-01-01' },
+          { 'Text_Label' => 'test2', 'Date_Label' => '2023-01-02' }
+        ]
+      end
+
+      it 'queries for only those fields' do
+        expected = 'SELECT Text_Label, Date_Label FROM Whizbang__c'
+        Whizbang.pluck(:text, :date)
+        expect(client).to have_received(:query).with(expected)
+      end
+
+      it 'returns an array of arrays of casted values in the correct order' do
+        expected = [
+          ['test1', Date.new(2023, 1, 1)],
+          ['test2', Date.new(2023, 1, 2)]
+        ]
+        expect(Whizbang.pluck(:text, :date)).to match_array(expected)
+      end
+    end
+  end
+
   describe '#reload' do
     let(:client) do
       double("sfdc_client", query: [Restforce::Mash.new(Id: 1, Name: 'Jeff')])


### PR DESCRIPTION
Closes #27 

Additional notes:

- The returned field values are casted according to their attribute types, like in ActiveRecord.
- Calling `pluck` without providing any fields (e.g., `Model.pluck`) returns all fields for that model.  This is the same behavior as ActiveRecord, which does a `SELECT *`.