### PR TITLE
Allow nil datetimes as datetime fields

### DIFF
--- a/lib/active_force/field.rb
+++ b/lib/active_force/field.rb
@@ -12,7 +12,7 @@ module ActiveForce
     def value_for_hash value
       case as
       when :datetime
-        value.to_fs(:iso8601)
+        value&.to_fs(:iso8601)
       else
         value
       end

--- a/spec/active_force/field_spec.rb
+++ b/spec/active_force/field_spec.rb
@@ -24,5 +24,11 @@ describe ActiveForce::Field do
       names = field.new(:time, as: :datetime)
       expect(names.value_for_hash current_time).to eq current_time.to_fs(:iso8601)
     end
+
+    it 'a datetime field whose value is nil' do
+      current_time = nil
+      names = field.new(:time, as: :datetime)
+      expect(names.value_for_hash current_time).to be_nil
+    end
   end
 end


### PR DESCRIPTION
Currently ActiveForce will throw an exception if you attempt to update a datetime field to be nil.  This PR adds a safe call to to_fs in Field.value_for_hash.