### PR TITLE
Persist default value field to salesforce when the overridden value is …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Not released
 
+- Fix `default` in models when default value is overridden by the same value, it is still sent to salesforce
+
 ## 0.15.1
 
 - Revert new `pluck` implementation due to compatibility issues (https://github.com/Beyond-Finance/active_force/pull/60)

--- a/lib/active_force/sobject.rb
+++ b/lib/active_force/sobject.rb
@@ -227,9 +227,13 @@ module ActiveForce
     end
 
     def attributes_for_create
-      @attributes.each_value.select { |value| value.is_a?(ActiveModel::Attribute::UserProvidedDefault) }
-                            .map(&:name)
-                            .concat(changed)
+      default_attributes.concat(changed)
+    end
+
+    def default_attributes
+      @attributes.each_value.select do |value| 
+        value.is_a?(ActiveModel::Attribute::UserProvidedDefault) || value.instance_values["original_attribute"].is_a?(ActiveModel::Attribute::UserProvidedDefault)
+      end.map(&:name)
     end
 
     def attributes_for_update

--- a/spec/active_force/sobject_spec.rb
+++ b/spec/active_force/sobject_spec.rb
@@ -96,6 +96,20 @@ describe ActiveForce::SObject do
         it 'sets percent field upon object instantiation' do
           expect(subject.new(**instantiation_attributes)[:percent]).to eq(percent)
         end
+
+        context 'when the override to default value is the same as the default value' do
+          let(:percent) { 50.0 }
+
+          it 'sends percent to salesforce' do
+            expect(client).to receive(:create!)
+                          .with(anything, hash_including('Percent_Label' => percent))
+            subject.create(**instantiation_attributes)
+          end
+
+          it 'sets percent field upon object instantiation' do
+            expect(subject.new(**instantiation_attributes)[:percent]).to eq(percent)
+          end
+        end
       end
     end
 


### PR DESCRIPTION
…same as default value

There is an edge case with Sobject default fields where if we override the default field, with the same value as the default -> the value does not get persisted to salesforce.

This PR fixes that.