### PR TITLE
Prep for 17.0 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Not released
 
+## 0.17.0
+
 - Fix bug with has_many queries due to query method chaining mutating in-place (https://github.com/Beyond-Finance/active_force/pull/10)
 
 ## 0.16.0

--- a/lib/active_force/version.rb
+++ b/lib/active_force/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActiveForce
-  VERSION = '0.16.0'
+  VERSION = '0.17.0'
 end


### PR DESCRIPTION
While I could have opted to do `16.1` instead it felt like enough of the behavior has changed, despite it being a bugfix, to warrent bumping the minor version.