### PR TITLE
Fix eager loading of scoped associations. Previously the scope was no…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Not released
 
+- Fix eager loading of scoped associations. (https://github.com/Beyond-Finance/active_force/pull/67)
 - Adding `.blank?`, `.present?`, and `.any?` delegators to `ActiveQuery`. (https://github.com/Beyond-Finance/active_force/pull/68)
 - Adding `update` and `update!` class methods on `SObject`. (https://github.com/Beyond-Finance/active_force/pull/66)
 

--- a/lib/active_force/association/association.rb
+++ b/lib/active_force/association/association.rb
@@ -26,6 +26,14 @@ module ActiveForce
         options[:relationship_name] || relation_model.to_s.constantize.table_name
       end
 
+      def scoped_as
+        options[:scoped_as] || nil
+      end
+
+      def scoped?
+        options[:scoped_as].present?
+      end
+
       ###
       # Does this association's relation_model represent
       # +sfdc_table_name+? Examples of +sfdc_table_name+


### PR DESCRIPTION
…t applied.  Scopes that accept arguments cannot be used as they are expecting an instance to be passed to them and if we are eager loading there is no instance to reference.