### PR TITLE
Add support for limit(n)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix eager loading of scoped associations. (https://github.com/Beyond-Finance/active_force/pull/67)
 - Adding `.blank?`, `.present?`, and `.any?` delegators to `ActiveQuery`. (https://github.com/Beyond-Finance/active_force/pull/68)
 - Adding `update` and `update!` class methods on `SObject`. (https://github.com/Beyond-Finance/active_force/pull/66)
+- Allow an argument to `last` allowing the query to select the `last(n)` records. Default is 1. (https://github.com/Beyond-Finance/active_force/pull/66)
 
 ## 0.17.0
 

--- a/lib/active_force/query.rb
+++ b/lib/active_force/query.rb
@@ -81,8 +81,8 @@ module ActiveForce
       limit 1
     end
 
-    def last
-      order("Id DESC").limit(1)
+    def last(limit = 1)
+      order("Id DESC").limit(limit)
     end
 
     def join object_query

--- a/spec/active_force/query_spec.rb
+++ b/spec/active_force/query_spec.rb
@@ -168,14 +168,30 @@ describe ActiveForce::Query do
   end
 
   describe '.last' do
-    it 'should return the query for the last record' do
-      expect(query.last.to_s).to eq 'SELECT Id, name, etc FROM table_name ORDER BY Id DESC LIMIT 1'
+    context 'without any argument' do
+      it 'should return the query for the last record' do
+        expect(query.last.to_s).to eq 'SELECT Id, name, etc FROM table_name ORDER BY Id DESC LIMIT 1'
+      end
+
+      it "should not update the original query" do
+        new_query = query.last
+        expect(query.to_s).to eq "SELECT Id, name, etc FROM table_name"
+        expect(new_query.to_s).to eq 'SELECT Id, name, etc FROM table_name ORDER BY Id DESC LIMIT 1'
+      end
     end
 
-    it "should not update the original query" do
-      new_query = query.last
-      expect(query.to_s).to eq "SELECT Id, name, etc FROM table_name"
-      expect(new_query.to_s).to eq 'SELECT Id, name, etc FROM table_name ORDER BY Id DESC LIMIT 1'
+    context 'with an argument' do
+      let(:last_argument) { 3 }
+
+      it 'should return the query for the last n records' do
+        expect(query.last(last_argument).to_s).to eq "SELECT Id, name, etc FROM table_name ORDER BY Id DESC LIMIT #{last_argument}"
+      end
+
+      it "should not update the original query" do
+        new_query = query.last last_argument
+        expect(query.to_s).to eq "SELECT Id, name, etc FROM table_name"
+        expect(new_query.to_s).to eq "SELECT Id, name, etc FROM table_name ORDER BY Id DESC LIMIT #{last_argument}"
+      end
     end
   end
 


### PR DESCRIPTION
Adds support for `limit` arguments:

```ruby
cr = Af::CrLiability.includes(:cr_liability_comments).last(3)
...

...FROM+Cr_liability__c+ORDER+BY+Id+DESC+LIMIT+3\"}
```