### PR TITLE
Nested select statements

### DIFF
--- a/lib/active_force/active_query.rb
+++ b/lib/active_force/active_query.rb
@@ -229,7 +229,6 @@ module ActiveForce
     end
 
     def result
-      binding.pry
       sfdc_client.query(self.to_s)
     end
 

--- a/lib/active_force/association/association.rb
+++ b/lib/active_force/association/association.rb
@@ -26,6 +26,14 @@ module ActiveForce
         options[:relationship_name] || relation_model.to_s.constantize.table_name
       end
 
+      def scoped_as
+        options[:scoped_as] || nil
+      end
+
+      def scoped?
+        options[:scoped_as].present?
+      end
+
       ###
       # Does this association's relation_model represent
       # +sfdc_table_name+? Examples of +sfdc_table_name+

--- a/lib/active_force/association/eager_load_builder_for_nested_includes.rb
+++ b/lib/active_force/association/eager_load_builder_for_nested_includes.rb
@@ -46,7 +46,7 @@ module ActiveForce
         return nil if query_fields.blank?
         query_fields_with_association = query_fields.find { |nested_field| nested_field[association.relation_name].present? }
         return nil if query_fields_with_association.blank?
-        query_fields_with_association[association.relation_name]
+        query_fields_with_association[association.relation_name].map { |field| association.relation_model.mappings[field] }
       end
 
       def build_hash_includes(relation, model = current_sobject, parent_association_field = nil)

--- a/lib/active_force/association/eager_load_builder_for_nested_includes.rb
+++ b/lib/active_force/association/eager_load_builder_for_nested_includes.rb
@@ -6,18 +6,19 @@ module ActiveForce
     class EagerLoadBuilderForNestedIncludes
 
       class << self
-        def build(relations, current_sobject, parent_association_field = nil)
-          new(relations, current_sobject, parent_association_field).projections
+        def build(relations, current_sobject, parent_association_field = nil, query_fields = nil)
+          new(relations, current_sobject, parent_association_field, query_fields).projections
         end
       end
 
-      attr_reader :relations, :current_sobject, :association_mapping, :parent_association_field, :fields
+      attr_reader :relations, :current_sobject, :association_mapping, :parent_association_field, :fields, :query_fields
 
-      def initialize(relations, current_sobject, parent_association_field = nil)
+      def initialize(relations, current_sobject, parent_association_field = nil, query_fields = nil)
         @relations = [relations].flatten
         @current_sobject = current_sobject
         @association_mapping = {}
         @parent_association_field = parent_association_field
+        @query_fields = query_fields
         @fields = []
       end
 
@@ -37,8 +38,15 @@ module ActiveForce
       end
 
       def build_includes(association)
-        fields.concat(EagerLoadProjectionBuilder.build(association, parent_association_field))
+        fields.concat(EagerLoadProjectionBuilder.build(association, parent_association_field, query_fields_for(association)))
         association_mapping[association.sfdc_association_field.downcase] = association.relation_name
+      end
+
+      def query_fields_for(association)
+        return nil if query_fields.blank?
+        query_fields_with_association = query_fields.find { |nested_field| nested_field[association.relation_name].present? }
+        return nil if query_fields_with_association.blank?
+        query_fields_with_association[association.relation_name]
       end
 
       def build_hash_includes(relation, model = current_sobject, parent_association_field = nil)
@@ -63,9 +71,10 @@ module ActiveForce
 
       def build_relation(association, nested_includes)
         sub_query = Query.new(association.sfdc_association_field)
-        sub_query.fields association.relation_model.fields
+        selected_fields = query_fields_for(association) || association.relation_model.fields
+        sub_query.fields selected_fields
         association_mapping[association.sfdc_association_field.downcase] = association.relation_name
-        nested_includes_query = self.class.build(nested_includes, association.relation_model)
+        nested_includes_query = self.class.build(nested_includes, association.relation_model, nil, query_fields)
         sub_query.fields nested_includes_query[:fields]
         { fields: ["(#{sub_query})"], association_mapping: nested_includes_query[:association_mapping] }
       end
@@ -77,7 +86,7 @@ module ActiveForce
         else
           current_parent_association_field = association.sfdc_association_field
         end
-        self.class.build(nested_includes, association.relation_model, current_parent_association_field)
+        self.class.build(nested_includes, association.relation_model, current_parent_association_field, query_fields)
       end
     end
   end

--- a/lib/active_force/query.rb
+++ b/lib/active_force/query.rb
@@ -1,6 +1,6 @@
 module ActiveForce
   class Query
-    attr_reader :table
+    attr_reader :table, :query_fields
 
     def initialize table
       @table = table

--- a/lib/active_force/select_builder.rb
+++ b/lib/active_force/select_builder.rb
@@ -1,0 +1,43 @@
+module ActiveForce
+  class SelectBuilder
+    extend Forwardable
+
+    attr_reader :selected_fields, :nested_query_fields, :non_nested_query_fields, :query
+    def_delegators :sobject, :mappings
+
+    def initialize(selected_fields, query)
+      @query = query
+      @selected_fields = selected_fields
+      @non_nested_query_fields = []
+      @nested_query_fields = []
+    end
+
+    def parse
+      selected_fields.each do |field|
+        case field
+        when Symbol
+          non_nested_query_fields << query.mappings[field]
+        when Hash
+          populate_nested_query_fields(field)
+        when String
+          non_nested_query_fields << field
+        end
+      end
+      {non_nested_query_fields: non_nested_query_fields, nested_query_fields: nested_query_fields}
+    end
+
+    private
+
+    def populate_nested_query_fields(field)
+      field.each do |key, value|
+        case value
+        when Symbol
+          field[key] = [value]
+        when Hash
+          raise ArgumentError, 'Nested Hash is not supported in select statement, you may wish to use an Array'
+        end
+      end
+      nested_query_fields << field
+    end
+  end
+end

--- a/spec/active_force/sobject/includes_spec.rb
+++ b/spec/active_force/sobject/includes_spec.rb
@@ -43,6 +43,13 @@ module ActiveForce
           expect(territory.quota.id).to eq "321"
         end
 
+        context 'when nested select statement' do
+          it 'formulates the correct SOQL query' do
+            soql = Salesforce::Territory.select(:id, :quota_id, quota: :id).includes(:quota).where(id: '123').to_s
+            expect(soql).to eq "SELECT Id, QuotaId, QuotaId.Id FROM Territory WHERE (Id = '123')"
+          end
+        end
+
         context 'with namespaced SObjects' do
           it 'queries the API for the associated record' do
             soql = Salesforce::Territory.includes(:quota).where(id: '123').to_s
@@ -156,6 +163,13 @@ module ActiveForce
       end
 
       context 'has_many' do
+        context 'when nested select statement' do
+          it 'formulates the correct SOQL query' do
+            soql = Account.select(opportunities: :id).includes(:opportunities).where(id: '123').to_s
+            expect(soql).to eq "SELECT Id, OwnerId, (SELECT Id, FROM Opportunities) FROM Account WHERE (Id = '123')"
+          end
+        end
+
         context 'with standard objects' do
           it 'formulates the correct SOQL query' do
             soql = Account.includes(:opportunities).where(id: '123').to_s

--- a/spec/active_force/sobject/includes_spec.rb
+++ b/spec/active_force/sobject/includes_spec.rb
@@ -166,7 +166,7 @@ module ActiveForce
         context 'when nested select statement' do
           it 'formulates the correct SOQL query' do
             soql = Account.select(opportunities: :id).includes(:opportunities).where(id: '123').to_s
-            expect(soql).to eq "SELECT Id, OwnerId, (SELECT Id, FROM Opportunities) FROM Account WHERE (Id = '123')"
+            expect(soql).to eq "SELECT Id, OwnerId, (SELECT Id FROM Opportunities) FROM Account WHERE (Id = '123')"
           end
         end
 


### PR DESCRIPTION
This PR allows the `.select` statement on an ActiveForce object to take in values for nested objects. When a nested select statement is combined with a nested includes statement, you can limit the number of fields on nested objects.

example:
```
Comment.select(:body, :post_id, post: [:title, :blog_id]).include(:post)
```