### PR TITLE
Bugfix: Transform NULL values for SF Bulk API, which expects "#N/A"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Not released
 
 - Change `.first` to not query the API if records have already been retrieved (https://github.com/Beyond-Finance/active_force/pull/73)
+- Bugfix: Transform NULL values for SF Bulk API, which expects "#N/A" (https://github.com/Beyond-Finance/active_force/pull/74)
 
 ## 0.19.0
 

--- a/lib/active_force/bulk/records.rb
+++ b/lib/active_force/bulk/records.rb
@@ -16,9 +16,24 @@ module ActiveForce
       end
 
       def self.parse_from_attributes(records)
+        # Sorting ensures that the headers line up with the values for the CSV
         headers = records.first.keys.sort.map(&:to_s)
-        data = records.map { |r| r.sort.pluck(-1) }
+        data = records.map do |r|
+           r.transform_values { |v| transform_value_for_sf(v) }.sort.pluck(-1)
+        end
         new(headers: headers, data: data)
+      end
+
+      # SF expects a special value for setting a column to be NULL.
+      def self.transform_value_for_sf(value)
+        case value
+        when NilClass
+          '#N/A'
+        when Time
+          value.iso8601
+        else
+          value.to_s
+        end
       end
     end
   end

--- a/lib/active_force/bulk/records.rb
+++ b/lib/active_force/bulk/records.rb
@@ -3,6 +3,8 @@ require 'csv'
 module ActiveForce
   module Bulk
     class Records
+      NULL_VALUE = '#N/A'.freeze
+
       attr_reader :headers, :data
       def initialize(headers:, data:)
         @headers = headers
@@ -28,7 +30,7 @@ module ActiveForce
       def self.transform_value_for_sf(value)
         case value
         when NilClass
-          '#N/A'
+          NULL_VALUE
         when Time
           value.iso8601
         else

--- a/spec/active_force/bulk/record_spec.rb
+++ b/spec/active_force/bulk/record_spec.rb
@@ -9,11 +9,13 @@ describe ActiveForce::Bulk::Records do
       %w[value3 value4],
     ]
   end
+
   describe '#to_csv' do
     it 'returns CSV with headers' do
       expect(subject.to_csv).to eq "header1,header2\nvalue1,value2\nvalue3,value4\n"
     end
   end
+
   describe '::parse_from_attributes' do
     subject { described_class.parse_from_attributes(attributes) }
     let(:attributes) do
@@ -27,6 +29,26 @@ describe ActiveForce::Bulk::Records do
       expect(records).to be_a described_class
       expect(records.headers).to eq headers
       expect(records.data).to eq data
+    end
+
+    context 'when there are NULL values' do
+      let(:attributes) do
+        [
+          { header1: nil, header2: 'value2'},
+          { header1: 'value3', header2: nil},
+        ]
+      end
+      let(:data) do
+        [
+          %w[#N/A value2],
+          %w[value3 #N/A],
+        ]
+      end
+
+      it 'substitutes the expected SF value for NULL' do
+        records = subject
+        expect(records.data).to eq data
+      end
     end
   end
 end


### PR DESCRIPTION
Need to transform `nil` into `#N/A` for the Salesforce Bulk API to pick up the change. See [here](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/datafiles_prepare_csv.htm#:~:text=Empty%20field%20values%20are%20ignored%20when%20you%20update%20records.%20To%20set%20a%20field%20value%20to%20null%2C%20use%20a%20field%20value%20of%20%23N/A.).