### PR TITLE
Fix missing `nil` attributes in SObject.update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Not released
 
+- Fix `.update` and `.update!`: include given `nil` valued attributes in request (https://github.com/Beyond-Finance/active_force/pull/79)
 - Change `.first` to not query the API if records have already been retrieved (https://github.com/Beyond-Finance/active_force/pull/77)
 
 ## 0.20.1

--- a/lib/active_force/sobject.rb
+++ b/lib/active_force/sobject.rb
@@ -34,7 +34,23 @@ module ActiveForce
       def_delegators :query, :not, :or, :where, :first, :last, :all, :find, :find!, :find_by, :find_by!, :sum, :count, :includes, :limit, :order, :select, :none
       def_delegators :mapping, :table, :table_name, :custom_table?, :mappings
 
+      def update(id, attributes)
+        prepare_for_update(id, attributes).update
+      end
+
+      def update!(id, attributes)
+        prepare_for_update(id, attributes).update!
+      end
+
       private
+
+      def prepare_for_update(id, attributes)
+        new(attributes.merge(id: id)).tap do |obj|
+          attributes.each do |name, value|
+            obj.public_send("#{name}_will_change!") if value.nil?
+          end
+        end
+      end
 
       ###
       # Provide each subclass with a default id field. Can be overridden
@@ -129,14 +145,6 @@ module ActiveForce
 
     def self.create! args
       new(args).create!
-    end
-
-    def self.update(id, attributes)
-      new(attributes.merge(id: id)).update
-    end
-
-    def self.update!(id, attributes)
-      new(attributes.merge(id: id)).update!
     end
 
     def save!

--- a/spec/active_force/sobject_spec.rb
+++ b/spec/active_force/sobject_spec.rb
@@ -321,6 +321,15 @@ describe ActiveForce::SObject do
           .and_return(true)
         Whizbang.update('12345678', text: 'my text')
       end
+
+      it 'includes given nil values in the request' do
+        allow(client).to receive(:update!).and_return(true)
+        Whizbang.update('test123', text: nil, date: nil)
+        expect(client).to have_received(:update!).with(
+          Whizbang.table_name,
+          { 'Id' => 'test123', 'Text_Label' => nil, 'Date_Label' => nil, 'Updated_From__c' => 'Rails' }
+        )
+      end
     end
 
     describe 'self.update!' do
@@ -329,6 +338,15 @@ describe ActiveForce::SObject do
           .with(Whizbang.table_name, { 'Id' => '123456789', 'Text_Label' => 'some other text', 'Updated_From__c' => 'Rails' })
           .and_return(true)
         Whizbang.update('123456789', text: 'some other text')
+      end
+
+      it 'includes given nil values in the request' do
+        allow(client).to receive(:update!).and_return(true)
+        Whizbang.update!('test123', text: nil, date: nil)
+        expect(client).to have_received(:update!).with(
+          Whizbang.table_name,
+          { 'Id' => 'test123', 'Text_Label' => nil, 'Date_Label' => nil, 'Updated_From__c' => 'Rails' }
+        )
       end
     end
   end


### PR DESCRIPTION
Previously, calling `SObject.update(id, a: nil)` or `SObject.update!(id, a: nil)` would omit `'A' => nil` from the Restforce request.  Consequently, the field would not be updated to `NULL` in Salesforce, despite the clear intention of the caller to do that.

This is because `.update` creates an instance, passing in the given attributes, and then calls `#update` on it.  That method only includes changed attributes in the request.  And since a new instance's attribute is `nil` by default, setting it to `nil` does not register it as changed.

This PR fixes this by forcing any attributes given to `SObject.update` or `SObject.update!` with `nil` values to register a change on the model by using the `ActiveModel::Dirty#*_will_change!` method.