### PR TITLE
Raise `UnknownAttributeError` if `.where` is given invalid attribute names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Not released
 
-- Include "invalid" attribute keys in query generated with `.where` (https://github.com/Beyond-Finance/active_force/pull/80) 
+- Raise `UnknownFieldError` if `.where` is given non-existent attribute names (https://github.com/Beyond-Finance/active_force/pull/80) 
 - Fix `.update` and `.update!`: include given `nil` valued attributes in request (https://github.com/Beyond-Finance/active_force/pull/79)
 - Change `.first` to not query the API if records have already been retrieved (https://github.com/Beyond-Finance/active_force/pull/77)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Not released
 
+- Include "invalid" attribute keys in query generated with `.where` (https://github.com/Beyond-Finance/active_force/pull/80) 
 - Fix `.update` and `.update!`: include given `nil` valued attributes in request (https://github.com/Beyond-Finance/active_force/pull/79)
 - Change `.first` to not query the API if records have already been retrieved (https://github.com/Beyond-Finance/active_force/pull/77)
 

--- a/lib/active_force/active_query.rb
+++ b/lib/active_force/active_query.rb
@@ -167,7 +167,8 @@ module ActiveForce
 
     def build_conditions_from_hash(hash)
       hash.map do |key, value|
-        applicable_predicate mappings[key], value
+        field = mappings.fetch(key, key&.to_s)
+        applicable_predicate(field, value)
       end
     end
 

--- a/spec/active_force/active_query_spec.rb
+++ b/spec/active_force/active_query_spec.rb
@@ -1,8 +1,17 @@
 require 'spec_helper'
 
+class TestSObject < ActiveForce::SObject
+  def self.decorate(records)
+    records
+  end
+end
+
 describe ActiveForce::ActiveQuery do
   let(:sobject) do
-    class_double(ActiveForce::SObject, { table_name: 'table_name', fields: [], mappings: mappings, name: 'TableName' })
+    class_double(
+      TestSObject,
+      { table_name: 'table_name', fields: [], mappings: mappings, name: 'TableName' }
+    )
   end
   let(:mappings){ { id: "Id", field: "Field__c", other_field: "Other_Field" } }
   let(:client) { double('client', query: nil) }
@@ -27,6 +36,11 @@ describe ActiveForce::ActiveQuery do
     it "should return an array of objects" do
       result = active_query.where("Text_Label = 'foo'").to_a
       expect(result).to be_a Array
+    end
+
+    it "should decorate the array of objects" do
+      expect(sobject).to receive(:decorate)
+      active_query.where("Text_Label = 'foo'").to_a
     end
   end
 

--- a/spec/active_force/active_query_spec.rb
+++ b/spec/active_force/active_query_spec.rb
@@ -296,6 +296,18 @@ describe ActiveForce::ActiveQuery do
         end
       end
     end
+
+    context 'when given attributes Hash with fields that do not exist on the SObject' do
+      it 'uses the given key in an eq condition' do
+        expected = 'SELECT Id FROM table_name WHERE (no_attribute = 1) AND (another_one = 2)'
+        expect(active_query.where(no_attribute: 1, 'another_one' => 2).to_s).to eq(expected)
+      end
+
+      it 'uses the given key in an in condition' do
+        expected = 'SELECT Id FROM table_name WHERE (no_attribute IN (1,2))'
+        expect(active_query.where(no_attribute: [1, 2]).to_s).to eq(expected)
+      end
+    end
   end
 
   describe '#not' do

--- a/spec/active_force/sobject_spec.rb
+++ b/spec/active_force/sobject_spec.rb
@@ -386,9 +386,9 @@ describe ActiveForce::SObject do
       expect { Whizbang.sum(nil) }.to raise_error(ArgumentError, 'field is required')
     end
 
-    it 'raises ArgumentError if given invalid field' do
+    it 'raises UnknownFieldError if given invalid field' do
       expect { Whizbang.sum(:invalid) }
-        .to raise_error(ArgumentError, /field 'invalid' does not exist on Whizbang/i)
+        .to raise_error(ActiveForce::UnknownFieldError, /unknown field 'invalid' for Whizbang/i)
     end
 
     it 'sends the correct query to the client' do
@@ -419,6 +419,11 @@ describe ActiveForce::SObject do
       expect(client).to receive(:query).with("SELECT #{Whizbang.fields.join ', '} FROM Whizbang__c WHERE (Id = 123) AND (Text_Label = 'foo') LIMIT 1")
       Whizbang.find_by id: 123, text: "foo"
     end
+
+    it 'raises UnknownFieldError if given invalid field' do
+      expect { Whizbang.find_by(xyz: 1) }
+        .to raise_error(ActiveForce::UnknownFieldError, /unknown field 'xyz' for Whizbang/)
+    end
   end
 
   describe "#find_by!" do
@@ -426,9 +431,15 @@ describe ActiveForce::SObject do
       expect(client).to receive(:query).with("SELECT #{Whizbang.fields.join ', '} FROM Whizbang__c WHERE (Id = 123) AND (Text_Label = 'foo') LIMIT 1").and_return([Restforce::Mash.new(Id: 123, text: 'foo')])
       Whizbang.find_by! id: 123, text: "foo"
     end
+
     it "raises if nothing found" do
       expect(client).to receive(:query).with("SELECT #{Whizbang.fields.join ', '} FROM Whizbang__c WHERE (Id = 123) AND (Text_Label = 'foo') LIMIT 1")
       expect { Whizbang.find_by! id: 123, text: "foo" }.to raise_error(ActiveForce::RecordNotFound)
+    end
+
+    it 'raises UnknownFieldError if given invalid field' do
+      expect { Whizbang.find_by!(xyz: 1) }
+        .to raise_error(ActiveForce::UnknownFieldError, /unknown field 'xyz' for Whizbang/)
     end
   end
 


### PR DESCRIPTION
Closes #26 