### PR TITLE
Fixes #91. Applies scopes to eager-loaded associations when they are nested.

### DIFF
--- a/lib/active_force/association/eager_load_builder_for_nested_includes.rb
+++ b/lib/active_force/association/eager_load_builder_for_nested_includes.rb
@@ -62,8 +62,9 @@ module ActiveForce
       private
 
       def build_relation(association, nested_includes)
-        sub_query = Query.new(association.sfdc_association_field)
-        sub_query.fields association.relation_model.fields
+        builder_class = ActiveForce::Association::EagerLoadProjectionBuilder.projection_builder_class(association)
+        projection_builder = builder_class.new(association)
+        sub_query = projection_builder.query_with_association_fields
         association_mapping[association.sfdc_association_field.downcase] = association.relation_name
         nested_includes_query = self.class.build(nested_includes, association.relation_model)
         sub_query.fields nested_includes_query[:fields]

--- a/spec/active_force/association_spec.rb
+++ b/spec/active_force/association_spec.rb
@@ -386,7 +386,7 @@ describe ActiveForce::SObject do
     it 'allows passing a foreign key' do
       Comment.belongs_to :post, foreign_key: :fancy_post_id
       allow(comment).to receive(:fancy_post_id).and_return "2"
-      expect(client).to receive(:query).with("SELECT Id, Title__c, BlogId FROM Post__c WHERE (Id = '2') LIMIT 1")
+      expect(client).to receive(:query).with("SELECT Id, Title__c, BlogId, IsActive FROM Post__c WHERE (Id = '2') LIMIT 1")
       comment.post
       Comment.belongs_to :post # reset association to original value
     end

--- a/spec/support/sobjects.rb
+++ b/spec/support/sobjects.rb
@@ -11,6 +11,7 @@ class Post < ActiveForce::SObject
   self.table_name = "Post__c"
   field :title
   field :blog_id, from: "BlogId"
+  field :is_active, from: "IsActive", as: :boolean
   has_many :comments
   has_many :impossible_comments, model: Comment, scoped_as: ->{ where('1 = 0') }
   has_many :reply_comments, model: Comment, scoped_as: ->(post){ where(body: "RE: #{post.title}").order('CreationDate DESC') }
@@ -25,6 +26,7 @@ class Blog < ActiveForce::SObject
   field :name, from: 'Name'
   field :link, from: 'Link__c'
   has_many :posts
+  has_many :active_posts, model: 'Post', scoped_as: -> { where(is_active: true) }
 end
 class Territory < ActiveForce::SObject
   field :quota_id, from: "Quota__c"
@@ -149,6 +151,7 @@ module Salesforce
   end
   class Account < ActiveForce::SObject
     field :business_partner
+    has_many :opportunities, model: Opportunity
     has_many :partner_opportunities, model: Opportunity, scoped_as: ->(account){ where(business_partner: account.business_partner).includes(:owner) }
   end
 end


### PR DESCRIPTION
I have previously fixed the eager loading of scoped associations (#67). The way the query was built when using includes with association nesting is different so it only worked if you didn't try to nest anything above it (e.g. `includes(:scoped_association)` and not `includes(scoped_association: :child)`.  I did a bit of a refactor to align them so the latter example will now work and because it's called recursively the scopes will be applied all the way down the chain.