### PR TITLE
Update ActiveQuery#select to accept a block

### DIFF
--- a/lib/active_force/active_query.rb
+++ b/lib/active_force/active_query.rb
@@ -78,9 +78,17 @@ module ActiveForce
       super build_condition args, rest
     end
 
-    def select *selected_fields
-      selected_fields.map! { |field| mappings[field] }
-      super *selected_fields
+    def select *selected_fields, &block
+      if block
+        result = []
+        self.each do |record|
+          result << record if block.call(record)
+        end
+        result
+      else
+        selected_fields.map! { |field| mappings[field] }
+        super *selected_fields
+      end
     end
 
     def ids

--- a/spec/active_force/active_query_spec.rb
+++ b/spec/active_force/active_query_spec.rb
@@ -96,24 +96,33 @@ describe ActiveForce::ActiveQuery do
     context 'when there are no records' do
       let(:api_result) { [] }
 
-      it 'returns true' do
+      it 'returns false' do
         result = active_query.where("Text_Label = 'foo'").any?
         expect(result).to be false
       end
     end
 
     context 'when records are returned' do
-      it 'returns false' do
+      it 'returns true' do
         result = active_query.where("Text_Label = 'foo'").any?
         expect(result).to be true
       end
     end
   end
 
-  describe "select only some field using mappings" do
-    it "should return a query only with selected field" do
-      new_query = active_query.select(:field)
-      expect(new_query.to_s).to eq("SELECT Field__c FROM table_name")
+  describe "#select" do
+    context "when passed a block" do
+      it "should return an array of records" do
+        result = active_query.select { |record| record.id == '123' }
+        expect(result).to be_a Array
+      end
+    end
+
+    context "when passed one or more fields" do
+      it "should return a query only with selected fields" do
+        new_query = active_query.select(:field)
+        expect(new_query.to_s).to eq("SELECT Field__c FROM table_name")
+      end
     end
   end
 

--- a/spec/active_force/active_query_spec.rb
+++ b/spec/active_force/active_query_spec.rb
@@ -112,9 +112,24 @@ describe ActiveForce::ActiveQuery do
 
   describe "#select" do
     context "when passed a block" do
-      it "should return an array of records" do
-        result = active_query.select { |record| record.id == '123' }
-        expect(result).to be_a Array
+      before do
+        allow(client).to receive(:query).and_return(api_result)
+      end
+
+      context "when records satisfy the block conditions" do
+        it "should return an array of records" do
+          result = active_query.select { |record| record == record }
+          expect(result).to be_a Array
+          expect(result.size).to eq 2
+        end
+      end
+
+      context "when records do not satisfy the block conditions" do
+        it "should return an empty array" do
+          result = active_query.select { |record| record != record }
+          expect(result).to be_a Array
+          expect(result.size).to eq 0
+        end
       end
     end
 


### PR DESCRIPTION
In an effort to alleviate some of the pain indicated in https://github.com/Beyond-Finance/active_force/issues/90, `.select` will now accept a block so we don't have to `.to_a` an `ActiveQuery` result to operate on it.