### PR TITLE
Nested select statements v.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Not released
 
+## 0.23.0
+- Add support for nested select statements that are used in conjuction with nested includes (https://github.com/Beyond-Finance/active_force/pull/102)
+
 ## 0.22.1
 - Fixes #94. Moved query logic and corrected ActiveQuery `ids` method (https://github.com/Beyond-Finance/active_force/pull/97)
 

--- a/README.md
+++ b/README.md
@@ -218,6 +218,17 @@ Comment.includes(post: :owner)
 Comment.includes({post: {owner: :account}})
 ```
 
+You can also use #select with a multi level #includes.
+
+Examples:
+
+```ruby
+Comment.select(:body, post: [:title, :is_active]).includes(post: :owner)
+Comment.select(:body, account: :owner_id).includes({post: {owner: :account}})
+```
+
+The Sobject name in the #select must match the Sobject in the #includes for the fields to be filtered.
+
 ### Aggregates
 
 Summing the values of a column:

--- a/lib/active_force/association/eager_load_builder_for_nested_includes.rb
+++ b/lib/active_force/association/eager_load_builder_for_nested_includes.rb
@@ -86,7 +86,7 @@ module ActiveForce
         else
           current_parent_association_field = association.sfdc_association_field
         end
-        self.class.build(nested_includes, association.relation_model, current_parent_association_field)
+        self.class.build(nested_includes, association.relation_model, current_parent_association_field, query_fields)
       end
     end
   end

--- a/lib/active_force/association/eager_load_builder_for_nested_includes.rb
+++ b/lib/active_force/association/eager_load_builder_for_nested_includes.rb
@@ -6,18 +6,19 @@ module ActiveForce
     class EagerLoadBuilderForNestedIncludes
 
       class << self
-        def build(relations, current_sobject, parent_association_field = nil)
-          new(relations, current_sobject, parent_association_field).projections
+        def build(relations, current_sobject, parent_association_field = nil, query_fields = nil)
+          new(relations, current_sobject, parent_association_field, query_fields).projections
         end
       end
 
-      attr_reader :relations, :current_sobject, :association_mapping, :parent_association_field, :fields
+      attr_reader :relations, :current_sobject, :association_mapping, :parent_association_field, :fields, :query_fields
 
-      def initialize(relations, current_sobject, parent_association_field = nil)
+      def initialize(relations, current_sobject, parent_association_field = nil, query_fields = nil)
         @relations = [relations].flatten
         @current_sobject = current_sobject
         @association_mapping = {}
         @parent_association_field = parent_association_field
+        @query_fields = query_fields
         @fields = []
       end
 
@@ -37,8 +38,15 @@ module ActiveForce
       end
 
       def build_includes(association)
-        fields.concat(EagerLoadProjectionBuilder.build(association, parent_association_field))
+        fields.concat(EagerLoadProjectionBuilder.build(association, parent_association_field, query_fields_for(association)))
         association_mapping[association.sfdc_association_field.downcase] = association.relation_name
+      end
+
+      def query_fields_for(association)
+        return nil if query_fields.blank?
+        query_fields_with_association = query_fields.find { |nested_field| nested_field[association.relation_name].present? }
+        return nil if query_fields_with_association.blank?
+        query_fields_with_association[association.relation_name].map { |field| association.relation_model.mappings[field] }
       end
 
       def build_hash_includes(relation, model = current_sobject, parent_association_field = nil)
@@ -63,10 +71,10 @@ module ActiveForce
 
       def build_relation(association, nested_includes)
         builder_class = ActiveForce::Association::EagerLoadProjectionBuilder.projection_builder_class(association)
-        projection_builder = builder_class.new(association)
+        projection_builder = builder_class.new(association, nil, query_fields_for(association))
         sub_query = projection_builder.query_with_association_fields
         association_mapping[association.sfdc_association_field.downcase] = association.relation_name
-        nested_includes_query = self.class.build(nested_includes, association.relation_model)
+        nested_includes_query = self.class.build(nested_includes, association.relation_model, nil, query_fields)
         sub_query.fields nested_includes_query[:fields]
         { fields: ["(#{sub_query})"], association_mapping: nested_includes_query[:association_mapping] }
       end

--- a/lib/active_force/association/eager_load_projection_builder.rb
+++ b/lib/active_force/association/eager_load_projection_builder.rb
@@ -25,8 +25,8 @@ module ActiveForce
 
       def projections
         builder_class = self.class.projection_builder_class(association)
-        builder_class.new(association, parent_association_field, query_fields).projections      end
-
+        builder_class.new(association, parent_association_field, query_fields).projections
+      end
     end
 
     class AbstractProjectionBuilder

--- a/lib/active_force/query.rb
+++ b/lib/active_force/query.rb
@@ -1,6 +1,6 @@
 module ActiveForce
   class Query
-    attr_reader :table
+    attr_reader :table, :query_fields
 
     def initialize table
       @table = table

--- a/lib/active_force/select_builder.rb
+++ b/lib/active_force/select_builder.rb
@@ -1,6 +1,5 @@
 module ActiveForce
   class SelectBuilder
-    extend Forwardable
 
     attr_reader :selected_fields, :nested_query_fields, :non_nested_query_fields, :query
 

--- a/lib/active_force/select_builder.rb
+++ b/lib/active_force/select_builder.rb
@@ -3,7 +3,6 @@ module ActiveForce
     extend Forwardable
 
     attr_reader :selected_fields, :nested_query_fields, :non_nested_query_fields, :query
-    def_delegators :sobject, :mappings
 
     def initialize(selected_fields, query)
       @query = query

--- a/lib/active_force/select_builder.rb
+++ b/lib/active_force/select_builder.rb
@@ -1,0 +1,43 @@
+module ActiveForce
+  class SelectBuilder
+    extend Forwardable
+
+    attr_reader :selected_fields, :nested_query_fields, :non_nested_query_fields, :query
+    def_delegators :sobject, :mappings
+
+    def initialize(selected_fields, query)
+      @query = query
+      @selected_fields = selected_fields
+      @non_nested_query_fields = []
+      @nested_query_fields = []
+    end
+
+    def parse
+      selected_fields.each do |field|
+        case field
+        when Symbol
+          non_nested_query_fields << query.mappings[field]
+        when Hash
+          populate_nested_query_fields(field)
+        when String
+          non_nested_query_fields << field
+        end
+      end
+      {non_nested_query_fields: non_nested_query_fields, nested_query_fields: nested_query_fields}
+    end
+
+    private
+
+    def populate_nested_query_fields(field)
+      field.each do |key, value|
+        case value
+        when Symbol
+          field[key] = [value]
+        when Hash
+          raise ArgumentError, 'Nested Hash is not supported in select statement, you may wish to use an Array'
+        end
+      end
+      nested_query_fields << field
+    end
+  end
+end

--- a/spec/active_force/sobject/includes_spec.rb
+++ b/spec/active_force/sobject/includes_spec.rb
@@ -48,6 +48,10 @@ module ActiveForce
             soql = Salesforce::Territory.select(:id, :quota_id, quota: :id).includes(:quota).where(id: '123').to_s
             expect(soql).to eq "SELECT Id, QuotaId, QuotaId.Id FROM Territory WHERE (Id = '123')"
           end
+
+          it 'errors when correct format is not followed' do
+            expect{Salesforce::Territory.select(:id, :quota_id, quota: {id: :quote}).includes(:quota).where(id: '123').to_s}.to raise_error ArgumentError
+          end
         end
 
         context 'with namespaced SObjects' do
@@ -308,6 +312,13 @@ module ActiveForce
       end
 
       context 'has_one' do
+        context 'when nested select statement is present' do
+          it 'formulates the correct SOQL query' do
+            soql = ClubMember.select(:name, :email, membership: :type).includes(:membership).to_s
+            expect(soql).to eq "SELECT Name, Email, (SELECT Type FROM Membership__r) FROM ClubMember__c"
+          end
+        end
+
         context 'when assocation has a scope' do
           it 'formulates the correct SOQL query with the scope applied' do
             soql = Post.includes(:last_comment).where(id: '1234').to_s

--- a/spec/active_force/sobject/includes_spec.rb
+++ b/spec/active_force/sobject/includes_spec.rb
@@ -43,6 +43,13 @@ module ActiveForce
           expect(territory.quota.id).to eq "321"
         end
 
+        context 'when nested select statement' do
+          it 'formulates the correct SOQL query' do
+            soql = Salesforce::Territory.select(:id, :quota_id, quota: :id).includes(:quota).where(id: '123').to_s
+            expect(soql).to eq "SELECT Id, QuotaId, QuotaId.Id FROM Territory WHERE (Id = '123')"
+          end
+        end
+
         context 'with namespaced SObjects' do
           it 'queries the API for the associated record' do
             soql = Salesforce::Territory.includes(:quota).where(id: '123').to_s
@@ -156,6 +163,13 @@ module ActiveForce
       end
 
       context 'has_many' do
+        context 'when nested select statement' do
+          it 'formulates the correct SOQL query' do
+            soql = Account.select(opportunities: :id).includes(:opportunities).where(id: '123').to_s
+            expect(soql).to eq "SELECT Id, OwnerId, (SELECT Id FROM Opportunities) FROM Account WHERE (Id = '123')"
+          end
+        end
+
         context 'with standard objects' do
           it 'formulates the correct SOQL query' do
             soql = Account.includes(:opportunities).where(id: '123').to_s

--- a/spec/active_force/sobject/includes_spec.rb
+++ b/spec/active_force/sobject/includes_spec.rb
@@ -182,6 +182,13 @@ module ActiveForce
           end
         end
 
+        context 'when normal select with nested includes' do
+          it 'formulates the correct SOQL query' do
+            soql = Blog.select(:id, :link).includes(posts: :comments).to_s
+            expect(soql).to eq "SELECT Id, Link__c, (SELECT Id, Title__c, BlogId, IsActive, (SELECT Id, PostId, PosterId__c, FancyPostId, Body__c FROM Comments__r) FROM Posts__r) FROM Blog__c"
+          end
+        end
+
         context 'with standard objects' do
           it 'formulates the correct SOQL query' do
             soql = Account.includes(:opportunities).where(id: '123').to_s

--- a/spec/active_force/sobject/includes_spec.rb
+++ b/spec/active_force/sobject/includes_spec.rb
@@ -52,6 +52,14 @@ module ActiveForce
           it 'errors when correct format is not followed' do
             expect{Salesforce::Territory.select(:id, :quota_id, quota: {id: :quote}).includes(:quota).where(id: '123').to_s}.to raise_error ArgumentError
           end
+
+          context 'when nested includes statement' do
+            it 'formulates the correct SOQL query' do
+              soql = Comment.select(:post_id, :body, post: [:title, :is_active], blog: :name).includes(post: :blog).to_s
+
+              expect(soql).to eq "SELECT PostId, Body__c, PostId.Title__c, PostId.IsActive, PostId.BlogId.Name FROM Comment__c"
+            end
+          end
         end
 
         context 'with namespaced SObjects' do


### PR DESCRIPTION
This PR allows the `.select` statement on an ActiveForce object to take in values for nested objects. When a nested select statement is combined with a nested includes statement, you can limit the number of fields on nested objects.

**example:**

```
Comment.select(:post_id, :body, post: [:title, :is_active], blog: :name).includes(post: :blog)
```

**example description:**
- `:post_id` and `:body` is your classic select statement. If no object is specified, it defaults to the SO object being queried. In this case `Comment`.

- `:post` is an object in the includes statement. `[:title, :is_active]` are the fields being selected on the post object.

- `:blog` is a nested object in the includes statement. `:name` is the field being selected on the `:blog` object.


It's important to note 

- While the includes statement is nested, the select statement is flat. In the above example :post and :blog are on the same level, despite :blog being nested inside :post in the includes statement.
- Plural matters. When you are using a has_many includes statement like `Post.includes(:comments)` and you want to filter the fields on comments with a nested select statement `Post.select(comments: :body).includes(:comments)` you will use the plural version of `:comments` in both the select and includes statement.
- If a field or Sobject does not exist, we do not error. Your query will still run without filtering anything.