### PR TITLE
Rails 8 Support

### DIFF
--- a/active_force.gemspec
+++ b/active_force.gemspec
@@ -25,8 +25,8 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 1.9.3'
 
-  spec.add_dependency 'activemodel', '~> 7.0'
-  spec.add_dependency 'activesupport', '~> 7.0'
+  spec.add_dependency 'activemodel', '>= 7.0'
+  spec.add_dependency 'activesupport', '>= 7.0'
   spec.add_dependency 'restforce',   '>= 5'
   spec.add_development_dependency 'rake', '>= 0'
   spec.add_development_dependency 'rspec', '>= 0'

--- a/lib/active_force/sobject.rb
+++ b/lib/active_force/sobject.rb
@@ -26,14 +26,15 @@ module ActiveForce
 
     define_model_callbacks :build, :create, :update, :save, :destroy
 
-    class_attribute :mappings, :table_name
+    class_attribute :mappings, :table_name_store
 
     attr_accessor :id, :title
 
     class << self
       extend Forwardable
       def_delegators :query, :not, :or, :where, :first, :last, :all, :find, :find!, :find_by, :find_by!, :sum, :count, :includes, :limit, :order, :select, :none
-      def_delegators :mapping, :table, :table_name, :custom_table?, :mappings
+      def_delegators :mapping, :table, :custom_table?, :mappings
+      alias_method :table_name=, :table_name_store=
 
       def update(id, attributes)
         prepare_for_update(id, attributes).update
@@ -41,6 +42,10 @@ module ActiveForce
 
       def update!(id, attributes)
         prepare_for_update(id, attributes).update!
+      end
+
+      def table_name
+        table_name_store || mapping.table_name
       end
 
       private
@@ -63,6 +68,10 @@ module ActiveForce
 
     def self.mapping
       @mapping ||= ActiveForce::Mapping.new name
+    end
+
+    def table_name
+      table_name_store || self.class.mapping.table_name
     end
 
     def self.fields

--- a/spec/active_force/sobject_spec.rb
+++ b/spec/active_force/sobject_spec.rb
@@ -375,6 +375,20 @@ describe ActiveForce::SObject do
     end
   end
 
+  describe '.table_name' do
+
+    context 'when no explicit table name is set' do
+      it 'derives the table name from the class name' do
+        expect(Whizbang.table_name).to eq('Whizbang__c')
+      end
+    end
+    context 'when explicit table name is set' do
+      it 'returns the explicit table name' do
+        expect(Whizbang2.table_name).to eq('Whiz_bang2__c')
+      end
+    end
+  end
+
   describe '.sum' do
     let(:response) { [Restforce::Mash.new(expr0: 22)] }
 

--- a/spec/support/whizbang.rb
+++ b/spec/support/whizbang.rb
@@ -28,3 +28,7 @@ class Whizbang < ActiveForce::SObject
   end
 
 end
+
+class Whizbang2 < Whizbang
+  self.table_name = 'Whiz_bang2__c'
+end


### PR DESCRIPTION
Rails 8 cannot be used on Rails repos that depend on `active_force`:

```
Could not find compatible versions

Because rails >= 8.0.2 depends on activesupport = 8.0.2
  and every version of active_force depends on activesupport ~> 7.0,
  rails >= 8.0.2 is incompatible with active_force >= 0.
So, because Gemfile depends on active_force >= 0
  and Gemfile depends on rails ~> 8.0.2,
  version solving has failed.
  ```

This PR updates the `activemodel` and `activesupport` to 8.0. 